### PR TITLE
Simplify a lot, increasing performance

### DIFF
--- a/test/Generics/Case/BoolSpec.hs
+++ b/test/Generics/Case/BoolSpec.hs
@@ -6,28 +6,28 @@ import qualified Test.Hspec as H
 import qualified Test.QuickCheck as Q
 import Util
 
-specBool ::
-  forall a.
-  (Show a, Eq a, Q.Arbitrary a) =>
-  String ->
-  (a -> a -> Bool -> a) ->
-  H.Spec
-specBool name f = specG @'[a, a, Bool] ("bool", bool) (name, f)
+type BoolFn r = Bool -> r -> r -> r
 
-boolL_ :: a -> a -> Bool -> a
-boolL_ x y b = boolL b x y
+type FunArgs r = '[Bool, r, r]
+
+manual :: BoolFn r
+manual b f t = bool f t b
+
+specBool ::
+  forall r.
+  (Show r, Eq r, Q.Arbitrary r) =>
+  String ->
+  BoolFn r ->
+  H.Spec
+specBool name f = specG @(FunArgs r) ("bool", manual) (name, f)
 
 spec :: H.Spec
 spec = do
   H.describe "()" $ do
-    specBool @() "boolR" boolR
-    specBool @() "boolL" boolL_
+    specBool @() "boolL" boolL
   H.describe "Char" $ do
-    specBool @Char "boolR" boolR
-    specBool @Char "boolL" boolL_
+    specBool @Char "boolL" boolL
   H.describe "String" $ do
-    specBool @String "boolR" boolR
-    specBool @String "boolL" boolL_
+    specBool @String "boolL" boolL
   H.describe "[Maybe (Int, String)]" $ do
-    specBool @[Maybe (Int, String)] "boolR" boolR
-    specBool @[Maybe (Int, String)] "boolL" boolL_
+    specBool @[Maybe (Int, String)] "boolL" boolL

--- a/test/Generics/Case/MaybeSpec.hs
+++ b/test/Generics/Case/MaybeSpec.hs
@@ -7,11 +7,15 @@ import qualified Test.QuickCheck as Q
 import Test.QuickCheck.Function
 import Util
 
-type MaybeFn a r = r -> (a -> r) -> Maybe a -> r
+type MaybeFn a r = Maybe a -> r -> (a -> r) -> r
 
-type FunArgs a r = '[r, Fun a r, Maybe a]
+type FunArgs a r = '[Maybe a, r, Fun a r]
 
 type MaybeFun a r = Chain (FunArgs a r) r
+
+manual :: MaybeFn a r
+manual Nothing r _ = r
+manual (Just a) _ f = f a
 
 specMaybe ::
   forall a r.
@@ -28,28 +32,21 @@ specMaybe ::
   H.Spec
 specMaybe name f =
   specG @(FunArgs a r)
-    ("maybe", mkFn maybe)
+    ("maybe", mkFn manual)
     (name, mkFn f)
 
 mkFn ::
   MaybeFn a r ->
   MaybeFun a r
-mkFn f r fn = f r (applyFun fn)
-
-maybeL_ :: MaybeFn a r
-maybeL_ x y b = maybeL b x y
+mkFn f m r fn = f m r (applyFun fn)
 
 spec :: H.Spec
 spec = do
   H.describe "Maybe () -> Char" $ do
-    specMaybe @() @Char "maybeR" maybeR
-    specMaybe @() @Char "maybeL" maybeL_
+    specMaybe @() @Char "maybeL" maybeL
   H.describe "Maybe Char -> Either String ()" $ do
-    specMaybe @Char @(Either String ()) "maybeR" maybeR
-    specMaybe @Char @(Either String ()) "maybeL" maybeL_
+    specMaybe @Char @(Either String ()) "maybeL" maybeL
   H.describe "Maybe String -> (Int, Either Integer Int)" $ do
-    specMaybe @String @(Int, Either Integer Int) "maybeR" maybeR
-    specMaybe @String @(Int, Either Integer Int) "maybeL" maybeL_
+    specMaybe @String @(Int, Either Integer Int) "maybeL" maybeL
   H.describe "Maybe [Maybe (Int, String)] -> (Int, [Either (Maybe ()) String])" $ do
-    specMaybe @[Maybe (Int, String)] @(Int, [Either (Maybe ()) String]) "maybeR" maybeR
-    specMaybe @(Maybe (Int, String)) @(Int, [Either (Maybe ()) String]) "maybeL" maybeL_
+    specMaybe @(Maybe (Int, String)) @(Int, [Either (Maybe ()) String]) "maybeL" maybeL


### PR DESCRIPTION
By inlining a lot (and getting rid of some SOP-like types such as `ChainF`), we can simplify the code a lot and improve performance by more than an order of magnitude.
