### PR TITLE
Test with GHC 9.12.2

### DIFF
--- a/generic-case.cabal
+++ b/generic-case.cabal
@@ -18,6 +18,7 @@ category:           Generics
 build-type:         Simple
 extra-doc-files:    CHANGELOG.md
 tested-with:
+  GHC == 9.12.2
   GHC == 9.10.1
   GHC == 9.8.2
   GHC == 9.6.5


### PR DESCRIPTION
Since [PR #116](https://github.com/haskell-actions/setup/pull/116) in `haskell-actions/setup`, we can test using GHC 9.12.2.