### PR TITLE
Implement `gcaseR`: functions before datatype

### DIFF
--- a/generic-case.cabal
+++ b/generic-case.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               generic-case
-version:            0.1.0.0
+version:            0.1.1.0
 synopsis:           Generic case analysis
 description:
   Generic case analysis in the vein of 'maybe', 'either' and 'bool',

--- a/src/Generics/Case.hs
+++ b/src/Generics/Case.hs
@@ -118,22 +118,29 @@ module Generics.Case
 
     -- ** Maybe
   , maybeL
+  , maybeR
 
     -- ** Either
   , eitherL
+  , eitherR
 
     -- ** Bool
   , boolL
+  , boolR
 
     -- ** Tuples
   , tupleL
+  , tupleR
   , tuple3L
+  , tuple3R
 
     -- ** Lists
   , listL
+  , listR
 
     -- ** Non-empty lists
   , nonEmptyL
+  , nonEmptyR
   )
 where
 
@@ -243,6 +250,23 @@ maybeL = gcase @(Maybe a)
 maybeL :: forall a r. Maybe a -> r -> (a -> r) -> r
 maybeL = gcase
 
+{- | 'maybe', implemented using 'gcaseR'.
+
+Equivalent type signature:
+
+@
+maybeR :: forall a r. 'AnalysisR' (Maybe a) r
+@
+
+The implementation is just:
+
+@
+maybeR = gcaseR @(Maybe a)
+@
+-}
+maybeR :: forall a r. r -> (a -> r) -> Maybe a -> r
+maybeR = gcaseR @(Maybe a)
+
 {- | Same as 'either', except the 'Either' comes before the case functions.
 
 Equivalent type signature:
@@ -259,6 +283,23 @@ eitherL = gcase
 -}
 eitherL :: forall a b r. Either a b -> (a -> r) -> (b -> r) -> r
 eitherL = gcase
+
+{- | 'either', implemented using 'gcaseR_'.
+
+Equivalent type signature:
+
+@
+eitherR :: forall a b r. 'AnalysisR' (Either a b) r
+@
+
+The implementation is just:
+
+@
+eitherR = gcaseR_ (Proxy :: Proxy (Either a b))
+@
+-}
+eitherR :: forall a b r. (a -> r) -> (b -> r) -> Either a b -> r
+eitherR = gcaseR_ (Proxy :: Proxy (Either a b))
 
 {- | Same as 'Data.Bool.bool', except the 'Bool' comes before the case functions.
 
@@ -277,6 +318,23 @@ boolL = gcase
 boolL :: forall r. Bool -> r -> r -> r
 boolL = gcase
 
+{- | 'Data.Bool.bool', implemented using 'gcaseR'.
+
+Equivalent type signature:
+
+@
+boolR :: forall r. 'AnalysisR' Bool r
+@
+
+The implementation is just:
+
+@
+boolR = gcaseR @Bool
+@
+-}
+boolR :: forall r. r -> r -> Bool -> r
+boolR = gcaseR @Bool
+
 {- | Case analysis on a list. Same as
 [list](https://hackage.haskell.org/package/extra/docs/Data-List-Extra.html#v:list)
 from @extra@, except the list comes before the case functions.
@@ -290,6 +348,19 @@ listL :: forall a r. 'Analysis' [a] r
 listL :: forall a r. [a] -> r -> (a -> [a] -> r) -> r
 listL = gcase
 
+{- | Case analysis on a list. Same as
+[list](https://hackage.haskell.org/package/extra/docs/Data-List-Extra.html#v:list)
+from @extra@.
+
+Equivalent type signature:
+
+@
+listR :: forall a r. 'AnalysisR' [a] r
+@
+-}
+listR :: forall a r. r -> (a -> [a] -> r) -> [a] -> r
+listR = gcaseR @[a]
+
 {- | Case analysis on a tuple. Same as 'uncurry', except the tuple comes before the case function.
 
 Equivalent type signature:
@@ -300,6 +371,17 @@ tupleL :: forall a b r. 'Analysis' (a, b) r
 -}
 tupleL :: forall a b r. (a, b) -> (a -> b -> r) -> r
 tupleL = gcase
+
+{- | Case analysis on a tuple. Interestingly, this is the same as 'uncurry'.
+
+Equivalent type signature:
+
+@
+tupleR :: forall a b r. 'AnalysisR' (a, b) r
+@
+-}
+tupleR :: forall a b r. (a -> b -> r) -> (a, b) -> r
+tupleR = gcaseR @(a, b)
 
 {- | Case analysis on a 3-tuple. Same as
 [uncurry3](https://hackage.haskell.org/package/extra/docs/Data-Tuple-Extra.html#v:uncurry3)
@@ -314,7 +396,20 @@ tuple3L :: forall a b c r. 'Analysis' (a, b, c) r
 tuple3L :: forall a b c r. (a, b, c) -> (a -> b -> c -> r) -> r
 tuple3L = gcase
 
-{- | Case analysis on a non-empty list.
+{- | Case analysis on a 3-tuple. Same as
+[uncurry3](https://hackage.haskell.org/package/extra/docs/Data-Tuple-Extra.html#v:uncurry3)
+from @extra@.
+
+Equivalent type signature:
+
+@
+tuple3R :: forall a b c r. 'AnalysisR' (a, b, c) r
+@
+-}
+tuple3R :: forall a b c r. (a -> b -> c -> r) -> (a, b, c) -> r
+tuple3R = gcaseR @(a, b, c)
+
+{- | Case analysis on a non-empty list, where the list comes before the case function.
 
 Equivalent type signature:
 
@@ -324,3 +419,14 @@ nonEmptyL :: forall a r. 'Analysis' (NonEmpty a) r
 -}
 nonEmptyL :: forall a r. NonEmpty a -> (a -> [a] -> r) -> r
 nonEmptyL = gcase
+
+{- | Case analysis on a non-empty list.
+
+Equivalent type signature:
+
+@
+nonEmptyR :: forall a r. 'AnalysisR' (NonEmpty a) r
+@
+-}
+nonEmptyR :: forall a r. (a -> [a] -> r) -> NonEmpty a -> r
+nonEmptyR = gcaseR @(NonEmpty a)

--- a/src/Generics/Case.hs
+++ b/src/Generics/Case.hs
@@ -222,7 +222,7 @@ from @extra@, except the tuple comes before the case function.
 Equivalent type signature:
 
 @
-tupleL :: forall a b c r. 'Analysis' (a, b, c) r
+tuple3L :: forall a b c r. 'Analysis' (a, b, c) r
 @
 -}
 tuple3L :: forall a b c r. (a, b, c) -> (a -> b -> c -> r) -> r

--- a/src/Generics/Chain.hs
+++ b/src/Generics/Chain.hs
@@ -125,6 +125,21 @@ toChain f = case sList @xs of
   SNil -> f Nil
   SCons -> \x -> toChain $ \xs -> f (I x :* xs)
 
+{- | This type family generalises 'Chains' when we want the inner 'Chain's to have a different
+return type to the overall function.
+
+@
+Chains' '[ '[x,y], '[z], '[]] ret final
+  ~ Chain '[x,y] final -> Chain '[z] final -> Chain '[] final -> ret
+  ~ (x -> y -> final)  -> (z -> final)     -> final           -> ret
+@
+
+It's used to implement both 'Chains' and 'ChainsR'.
+-}
+type family Chains' xss ret final where
+  Chains' '[] ret final = ret
+  Chains' (xs ': xss) ret final = Chain xs final -> Chains' xss ret final
+
 {- | The next level up from 'Chain': now we represent a function of functions.
 
 @
@@ -139,9 +154,7 @@ In an ideal world, we'd be able to write:
 type Chains xss r = Chain (Map (\xs -> Chain xs r) xss) r
 @
 -}
-type family Chains xss r where
-  Chains '[] r = r
-  Chains (xs ': xss) r = Chain xs r -> Chains xss r
+type Chains xss r = Chains' xss r r
 
 {- | Apply a series of chains. Used to implement 'Generics.Case.gcase'.
 

--- a/src/Generics/Chain.hs
+++ b/src/Generics/Chain.hs
@@ -54,7 +54,7 @@ f3__ :: Chain '[a, a -> a, a -> a -> a] a
 f3__ = f3_
 @
 
-'Chains' iterates on this concepts: it is a type-level family representing
+'Chains' iterates on this concept: it is a type-level family representing
 a function of functions. This lets us represent "case analysis" functions like
 'maybe' and 'either' nicely (see "Generics.Case"):
 
@@ -191,14 +191,14 @@ You can think of the signature and implementation of this function (ignoring the
 which just helps GHC understand the recursion) as being:
 
 @
-applyChains ::
+constChain ::
   r ->
   Chains xs1 r ->
   Chains xs2 r ->
   ... ->
   Chains xsn r ->
   r
-applyChains r _ _ ... _ = r
+constChain r _ _ ... _ = r
 @
 -}
 constChain :: forall xss r. r -> Shape xss -> Chains xss r

--- a/test/Generics/Case/BoolSpec.hs
+++ b/test/Generics/Case/BoolSpec.hs
@@ -8,10 +8,17 @@ import Util
 
 type BoolFn r = Bool -> r -> r -> r
 
+type BoolFnR r = r -> r -> Bool -> r
+
 type FunArgs r = '[Bool, r, r]
+
+type FunArgsR r = '[r, r, Bool]
 
 manual :: BoolFn r
 manual b f t = bool f t b
+
+manualR :: BoolFnR r
+manualR = bool
 
 specBool ::
   forall r.
@@ -21,13 +28,31 @@ specBool ::
   H.Spec
 specBool name f = specG @(FunArgs r) ("bool", manual) (name, f)
 
+specBoolR ::
+  forall r.
+  (Show r, Eq r, Q.Arbitrary r) =>
+  String ->
+  BoolFnR r ->
+  H.Spec
+specBoolR name f = specG @(FunArgsR r) ("bool", manualR) (name, f)
+
 spec :: H.Spec
 spec = do
-  H.describe "()" $ do
-    specBool @() "boolL" boolL
-  H.describe "Char" $ do
-    specBool @Char "boolL" boolL
-  H.describe "String" $ do
-    specBool @String "boolL" boolL
-  H.describe "[Maybe (Int, String)]" $ do
-    specBool @[Maybe (Int, String)] "boolL" boolL
+  H.describe "Left" $ do
+    H.describe "()" $ do
+      specBool @() "boolL" boolL
+    H.describe "Char" $ do
+      specBool @Char "boolL" boolL
+    H.describe "String" $ do
+      specBool @String "boolL" boolL
+    H.describe "[Maybe (Int, String)]" $ do
+      specBool @[Maybe (Int, String)] "boolL" boolL
+  H.describe "Right" $ do
+    H.describe "()" $ do
+      specBoolR @() "boolR" boolR
+    H.describe "Char" $ do
+      specBoolR @Char "boolR" boolR
+    H.describe "String" $ do
+      specBoolR @String "boolR" boolR
+    H.describe "[Maybe (Int, String)]" $ do
+      specBoolR @[Maybe (Int, String)] "boolR" boolR

--- a/test/Generics/Case/Custom/NoParamTypeSpec.hs
+++ b/test/Generics/Case/Custom/NoParamTypeSpec.hs
@@ -30,9 +30,15 @@ instance Q.Arbitrary NoParamType where
 
 type NPTFn r = NoParamType -> r -> (Int -> r) -> (String -> Char -> r) -> r
 
+type NPTFnR r = r -> (Int -> r) -> (String -> Char -> r) -> NoParamType -> r
+
 type FunArgs r = '[NoParamType, r, Fun Int r, Fun String (Fun Char r)]
 
+type FunArgsR r = '[r, Fun Int r, Fun String (Fun Char r), NoParamType]
+
 type NPTFun r = Chain (FunArgs r) r
+
+type NPTFunR r = Chain (FunArgsR r) r
 
 manual :: NPTFn r
 manual npt r fromInt fromStringChar = case npt of
@@ -40,8 +46,17 @@ manual npt r fromInt fromStringChar = case npt of
   NPT2 int -> fromInt int
   NPT3 string char -> fromStringChar string char
 
+manualR :: NPTFnR r
+manualR r fromInt fromStringChar npt = case npt of
+  NPT1 -> r
+  NPT2 int -> fromInt int
+  NPT3 string char -> fromStringChar string char
+
 nptL :: NPTFn r
 nptL = gcase @NoParamType
+
+nptR :: NPTFnR r
+nptR = gcaseR @NoParamType
 
 specNPT ::
   forall r.
@@ -57,18 +72,47 @@ specNPT name f =
     ("manual", mkFn manual)
     (name, mkFn f)
 
+specNPTR ::
+  forall r.
+  ( Q.Arbitrary r
+  , Show r
+  , Eq r
+  ) =>
+  String ->
+  NPTFnR r ->
+  H.Spec
+specNPTR name f =
+  specG @(FunArgsR r)
+    ("manual", mkFnR manualR)
+    (name, mkFnR f)
+
 mkFn ::
   NPTFn r ->
   NPTFun r
 mkFn f npt' r f1 f2 = f npt' r (applyFun f1) (applyFun <$> applyFun f2)
 
+mkFnR ::
+  NPTFnR r ->
+  NPTFunR r
+mkFnR f r f1 f2 = f r (applyFun f1) (applyFun <$> applyFun f2)
+
 spec :: H.Spec
 spec = do
-  H.describe "()" $ do
-    specNPT @() "nptL" nptL
-  H.describe "Char" $ do
-    specNPT @Char "nptL" nptL
-  H.describe "String" $ do
-    specNPT @String "nptL" nptL
-  H.describe "[Maybe (Int, String)]" $ do
-    specNPT @[Maybe (Int, String)] "nptL" nptL
+  H.describe "left" $ do
+    H.describe "()" $ do
+      specNPT @() "nptL" nptL
+    H.describe "Char" $ do
+      specNPT @Char "nptL" nptL
+    H.describe "String" $ do
+      specNPT @String "nptL" nptL
+    H.describe "[Maybe (Int, String)]" $ do
+      specNPT @[Maybe (Int, String)] "nptL" nptL
+  H.describe "right" $ do
+    H.describe "()" $ do
+      specNPTR @() "nptR" nptR
+    H.describe "Char" $ do
+      specNPTR @Char "nptR" nptR
+    H.describe "String" $ do
+      specNPTR @String "nptR" nptR
+    H.describe "[Maybe (Int, String)]" $ do
+      specNPTR @[Maybe (Int, String)] "nptR" nptR

--- a/test/Generics/Case/EitherSpec.hs
+++ b/test/Generics/Case/EitherSpec.hs
@@ -9,13 +9,21 @@ import Util
 
 type EitherFn a b r = Either a b -> (a -> r) -> (b -> r) -> r
 
+type EitherFnR a b r = (a -> r) -> (b -> r) -> Either a b -> r
+
 type FunArgs a b r = '[Either a b, Fun a r, Fun b r]
+
+type FunArgsR a b r = '[Fun a r, Fun b r, Either a b]
 
 type EitherFun a b r = Chain (FunArgs a b r) r
 
+type EitherFunR a b r = Chain (FunArgsR a b r) r
+
 manual :: EitherFn a b r
-manual (Left a) f _ = f a
-manual (Right b) _ g = g b
+manual e l r = either l r e
+
+manualR :: EitherFnR a b r
+manualR = either
 
 specEither ::
   forall a b r.
@@ -39,18 +47,55 @@ specEither name f =
     ("either", mkFn manual)
     (name, mkFn f)
 
+specEitherR ::
+  forall a b r.
+  ( Show a
+  , Function a
+  , Q.CoArbitrary a
+  , Q.Arbitrary a
+  , Show b
+  , Function b
+  , Q.CoArbitrary b
+  , Q.Arbitrary b
+  , Q.Arbitrary r
+  , Show r
+  , Eq r
+  ) =>
+  String ->
+  EitherFnR a b r ->
+  H.Spec
+specEitherR name f =
+  specG @(FunArgsR a b r)
+    ("either", mkFnR manualR)
+    (name, mkFnR f)
+
 mkFn ::
   EitherFn a b r ->
   EitherFun a b r
 mkFn e x f g = e x (applyFun f) (applyFun g)
 
+mkFnR ::
+  EitherFnR a b r ->
+  EitherFunR a b r
+mkFnR e f g = e (applyFun f) (applyFun g)
+
 spec :: H.Spec
 spec = do
-  H.describe "Either () Char -> Char" $ do
-    specEither @() @Char @Char "eitherL" eitherL
-  H.describe "Either Char String -> Either String ()" $ do
-    specEither @Char @String @(Either String ()) "eitherL" eitherL
-  H.describe "Either String (Maybe Integer) -> (Int, Either Integer Int)" $ do
-    specEither @String @(Maybe Integer) @(Int, Either Integer Int) "eitherL" eitherL
-  H.describe "Either [Maybe (Int, String)] Int -> (Int, [Either (Maybe ()) String])" $ do
-    specEither @(Maybe (Int, String)) @Int @(Int, [Either (Maybe ()) String]) "eitherL" eitherL
+  H.describe "left" $ do
+    H.describe "Either () Char -> Char" $ do
+      specEither @() @Char @Char "eitherL" eitherL
+    H.describe "Either Char String -> Either String ()" $ do
+      specEither @Char @String @(Either String ()) "eitherL" eitherL
+    H.describe "Either String (Maybe Integer) -> (Int, Either Integer Int)" $ do
+      specEither @String @(Maybe Integer) @(Int, Either Integer Int) "eitherL" eitherL
+    H.describe "Either [Maybe (Int, String)] Int -> (Int, [Either (Maybe ()) String])" $ do
+      specEither @(Maybe (Int, String)) @Int @(Int, [Either (Maybe ()) String]) "eitherL" eitherL
+  H.describe "right" $ do
+    H.describe "Either () Char -> Char" $ do
+      specEitherR @() @Char @Char "eitherR" eitherR
+    H.describe "Either Char String -> Either String ()" $ do
+      specEitherR @Char @String @(Either String ()) "eitherR" eitherR
+    H.describe "Either String (Maybe Integer) -> (Int, Either Integer Int)" $ do
+      specEitherR @String @(Maybe Integer) @(Int, Either Integer Int) "eitherR" eitherR
+    H.describe "Either [Maybe (Int, String)] Int -> (Int, [Either (Maybe ()) String])" $ do
+      specEitherR @(Maybe (Int, String)) @Int @(Int, [Either (Maybe ()) String]) "eitherR" eitherR

--- a/test/Generics/Case/MaybeSpec.hs
+++ b/test/Generics/Case/MaybeSpec.hs
@@ -9,13 +9,21 @@ import Util
 
 type MaybeFn a r = Maybe a -> r -> (a -> r) -> r
 
+type MaybeFnR a r = r -> (a -> r) -> Maybe a -> r
+
 type FunArgs a r = '[Maybe a, r, Fun a r]
+
+type FunArgsR a r = '[r, Fun a r, Maybe a]
 
 type MaybeFun a r = Chain (FunArgs a r) r
 
+type MaybeFunR a r = Chain (FunArgsR a r) r
+
 manual :: MaybeFn a r
-manual Nothing r _ = r
-manual (Just a) _ f = f a
+manual m r f = maybe r f m
+
+manualR :: MaybeFnR a r
+manualR = maybe
 
 specMaybe ::
   forall a r.
@@ -35,18 +43,51 @@ specMaybe name f =
     ("maybe", mkFn manual)
     (name, mkFn f)
 
+specMaybeR ::
+  forall a r.
+  ( Show a
+  , Function a
+  , Q.Arbitrary r
+  , Q.CoArbitrary a
+  , Q.Arbitrary a
+  , Show r
+  , Eq r
+  ) =>
+  String ->
+  MaybeFnR a r ->
+  H.Spec
+specMaybeR name f =
+  specG @(FunArgsR a r)
+    ("maybe", mkFnR manualR)
+    (name, mkFnR f)
+
 mkFn ::
   MaybeFn a r ->
   MaybeFun a r
 mkFn f m r fn = f m r (applyFun fn)
 
+mkFnR ::
+  MaybeFnR a r ->
+  MaybeFunR a r
+mkFnR f r fn = f r (applyFun fn)
+
 spec :: H.Spec
 spec = do
-  H.describe "Maybe () -> Char" $ do
-    specMaybe @() @Char "maybeL" maybeL
-  H.describe "Maybe Char -> Either String ()" $ do
-    specMaybe @Char @(Either String ()) "maybeL" maybeL
-  H.describe "Maybe String -> (Int, Either Integer Int)" $ do
-    specMaybe @String @(Int, Either Integer Int) "maybeL" maybeL
-  H.describe "Maybe [Maybe (Int, String)] -> (Int, [Either (Maybe ()) String])" $ do
-    specMaybe @(Maybe (Int, String)) @(Int, [Either (Maybe ()) String]) "maybeL" maybeL
+  H.describe "left" $ do
+    H.describe "Maybe () -> Char" $ do
+      specMaybe @() @Char "maybeL" maybeL
+    H.describe "Maybe Char -> Either String ()" $ do
+      specMaybe @Char @(Either String ()) "maybeL" maybeL
+    H.describe "Maybe String -> (Int, Either Integer Int)" $ do
+      specMaybe @String @(Int, Either Integer Int) "maybeL" maybeL
+    H.describe "Maybe [Maybe (Int, String)] -> (Int, [Either (Maybe ()) String])" $ do
+      specMaybe @(Maybe (Int, String)) @(Int, [Either (Maybe ()) String]) "maybeL" maybeL
+  H.describe "right" $ do
+    H.describe "Maybe () -> Char" $ do
+      specMaybeR @() @Char "maybeR" maybeR
+    H.describe "Maybe Char -> Either String ()" $ do
+      specMaybeR @Char @(Either String ()) "maybeR" maybeR
+    H.describe "Maybe String -> (Int, Either Integer Int)" $ do
+      specMaybeR @String @(Int, Either Integer Int) "maybeR" maybeR
+    H.describe "Maybe [Maybe (Int, String)] -> (Int, [Either (Maybe ()) String])" $ do
+      specMaybeR @(Maybe (Int, String)) @(Int, [Either (Maybe ()) String]) "maybeR" maybeR


### PR DESCRIPTION
Re-implement `gcaseR`, by converting `gcase` (which uses `Chains`) to a new type `ChainsR`. This looks
similar to the original implementation here, but without trying to do the recursion directly via `ChainsR` (which seems
to be impossible with the current implementation).

The important commits are:
b79ced205c39d9d65be74dcdc47b2a755afa3c4c - Generalise `Chains` to have different return types in the inner and outer chains
5a17f25da505e91df3431da8fcf9766353e7949d - `ChainsR` is basically the same as `Chains`, with the arguments in a different order
48058f8de3803bc28cc0eab9843c534444c5bd8c - Finally we can re-implement `gcaseR`

### Note

This is undoubtedly more ergonomic, since it allows us to use partial application nicely:

```haskell
let maybeToEither err = maybeR (Left err) Right
in  ...
```

However, this carries a slight performance impact. It will __always__ be faster to use 'gcase', so if performance is critical in your use-case, use that. Then again, if performance is __really__ critical, you'll always be better off writing your analysis function manually; or just pattern-matching directly.

### Note to self
Update Changelog before merging.
